### PR TITLE
Removing unessasary absolute paths

### DIFF
--- a/NetworkModule/NetworkModule-16In.stp
+++ b/NetworkModule/NetworkModule-16In.stp
@@ -27,4 +27,4 @@ Count=0
 Count=0
 [PROGRAM MEMORY]
 Count=1
-File0=C:\Users\Mike\Documents\COSMIC\FSE_Compilers\CXSTM8\NetworkModule\NetworkModule-16In.sx
+File0=NetworkModule-16In.sx

--- a/NetworkModule/NetworkModule-16Out.stp
+++ b/NetworkModule/NetworkModule-16Out.stp
@@ -27,4 +27,4 @@ Count=0
 Count=0
 [PROGRAM MEMORY]
 Count=1
-File0=C:\Users\Mike\Documents\COSMIC\FSE_Compilers\CXSTM8\NetworkModule\NetworkModule-16Out.sx
+File0=NetworkModule-16Out.sx

--- a/NetworkModule/NetworkModule-8Out.stp
+++ b/NetworkModule/NetworkModule-8Out.stp
@@ -27,4 +27,4 @@ Count=0
 Count=0
 [PROGRAM MEMORY]
 Count=1
-File0=C:\Users\Mike\Documents\COSMIC\FSE_Compilers\CXSTM8\NetworkModule\NetworkModule-8Out.sx
+File0=NetworkModule-8Out.sx

--- a/NetworkModule/NetworkModule-8OutMQTT.stp
+++ b/NetworkModule/NetworkModule-8OutMQTT.stp
@@ -27,4 +27,4 @@ Count=0
 Count=0
 [PROGRAM MEMORY]
 Count=1
-File0=C:\Users\Mike\Documents\COSMIC\FSE_Compilers\CXSTM8\NetworkModule\NetworkModule-8OutMQTT.sx
+File0=NetworkModule-8OutMQTT.sx

--- a/NetworkModule/NetworkModule.stp
+++ b/NetworkModule/NetworkModule.stp
@@ -27,4 +27,4 @@ Count=0
 Count=0
 [PROGRAM MEMORY]
 Count=1
-File0=C:\Users\Mike\Documents\COSMIC\FSE_Compilers\CXSTM8\NetworkModule\NetworkModule.sx
+File0=NetworkModule.sx


### PR DESCRIPTION
Project still works with relative paths. This is more convenient, because we can put source code anywhere we want.